### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,27 @@ ovirt-engine to reinstall the host id.
 
 ## Installation
 
-yum install ruby193-rubygem-ovirt_provision_plugin
+### Red Hat, CentOS, Fedora, Scientific Linux (rpm)
 
-[TODO: remove this section when plugin gets to official repo]
-Currently you can use:
-http://yum.theforeman.org/plugins/nightly/el6/x86_64/ruby193-rubygem-ovirt_provision_plugin-0.0.1-1.el6.noarch.rpm
+* [Foreman: How to Install a Plugin](http://theforeman.org/manuals/latest/index.html#6.1InstallaPlugin)
 
-The plugin requires also rbovirt updates, which can be found in:
-http://yum.theforeman.org/nightly/el6/x86_64/ruby193-rubygem-rbovirt-0.0.28-1.el6.noarch.rpm
+Set up the repo as explained in the link above, then run
+
+    # yum install ruby193-rubygem-ovirt_provision_plugin
+
+### Bundle (gem)
+
+Add the following to bundler.d/Gemfile.local.rb in your Foreman installation directory (/usr/share/foreman by default)
+
+    $ gem 'ovirt_provision_plugin'
+
+Then run `bundle install` and from the same directory.
+
+## Compatibility
+
+| Foreman | Plugin |
+| ---------------:| --------------:|
+| >= 1.6         | 1.0.0 - 1.0.1 |
 
 ## Contributing
 


### PR DESCRIPTION
I've removed the direct links to el6 rpms, which might not work for everyone. This plugin is already in the official repos for 1.6 and 1.7 so they can just use that. 

Rbovirt is a dependency so there's no need to tell people explicitely to install it. I've added a small section about installing from the gem directly too, and a foreman/plugin compatibility versions table too.