### PR TITLE
Update to version 0.1.0 of rbovirt

### DIFF
--- a/app/models/concerns/ovirt_provision_plugin/host_extensions.rb
+++ b/app/models/concerns/ovirt_provision_plugin/host_extensions.rb
@@ -63,7 +63,7 @@ module OvirtProvisionPlugin
         connection_opts = {}
         if not cr.public_key.blank?
           connection_opts[:datacenter_id] = cr.uuid
-          connection_opts[:ca_cert_store] = OpenSSL::X509::Store.new.add_cert(OpenSSL::X509::Certificate.new(cr.public_key))
+          connection_opts[:ca_cert] = cr.public_key
         end
         return OVIRT::Client.new("#{cr.user}", "#{cr.password}", "#{cr.url}", connection_opts)
       rescue OVIRT::OvirtException

--- a/ovirt_provision_plugin.gemspec
+++ b/ovirt_provision_plugin.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "deface"
-  s.add_dependency "rbovirt", ">= 0.0.27"
+  s.add_dependency "rbovirt", ">= 0.1.0"
 end


### PR DESCRIPTION
Version 0.1.0 of rbovirt replaces the ":ca_cert_store" parameter
containg an OpenSSL certificate store with a ":ca_cert" parameter that
contains a DER or PEM encoded string.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>