### PR TITLE
Update plugin dependencies

### DIFF
--- a/ovirt_provision_plugin.gemspec
+++ b/ovirt_provision_plugin.gemspec
@@ -13,6 +13,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "deface"
-  s.add_dependency "rbovirt", ">= 0.0.27"
+  s.add_dependency "ovirt-engine-sdk", ">= 4.1.3"
 end


### PR DESCRIPTION
Adding ovirt-engine-sdk instead of rbovirt.
Removing deface dependency - seems like its not in use.

Signed-off-by: Yaniv Bronhaim <ybronhei@redhat.com>