### PR TITLE
Fixes #28993 - Add description to plugin roles

### DIFF
--- a/lib/ovirt_provision_plugin/engine.rb
+++ b/lib/ovirt_provision_plugin/engine.rb
@@ -25,7 +25,8 @@ module OvirtProvisionPlugin
         end
 
         # Add a new role called 'Discovery' if it doesn't exist
-        role "OvirtProvisionPlugin", [:view_ovirt_provision_plugin]
+        role "OvirtProvisionPlugin", [:view_ovirt_provision_plugin],
+             "TODO: Description"
       end
     end
 


### PR DESCRIPTION
PR is part of  [Add default descriptions to all roles added from plugins](https://projects.theforeman.org/issues/28936) task.